### PR TITLE
docs: Update dependencies installed

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
                 <strong>1)</strong> Install the required dependencies:
             </p>
             <pre>
-sudo apt install git curl python3-pip exuberant-ctags ack-grep
+sudo apt install git curl python3-pip universal-ctags ack-grep
 sudo pip3 install pynvim flake8 pylint isort jedi</pre>
             </p>
             <p>
@@ -100,7 +100,7 @@ sudo pip3 install pynvim flake8 pylint isort jedi</pre>
                 <strong>1)</strong> Install the required dependencies:
             </p>
               <pre>
-sudo apt install git curl python3-pip exuberant-ctags ack-grep
+sudo apt install git curl python3-pip universal-ctags ack-grep
 sudo pip3 install pynvim flake8 pylint isort jedi</pre>
             </p>
             <p>


### PR DESCRIPTION
The exuberant-ctags project is unmaintained.  As a drop-in replacement raises universal-ctags.  Vim-airline supports either of them. 

This patch changes that in the installation instructions.